### PR TITLE
Updated 'lxml' version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cybox==2.1.0.21
 decorator==5.0.7
 fqdn==1.5.1
-lxml==4.6.3
+lxml==4.9.3
 mixbox==1.0.5
 ordered-set==4.0.2
 python-dateutil==2.8.1


### PR DESCRIPTION
Installations in some setups fail because of a deprecation error. Using a newer `lxml` version fixes the problem.